### PR TITLE
fix: Updates devcontainer

### DIFF
--- a/.devcontainer/recommended-Dockerfile
+++ b/.devcontainer/recommended-Dockerfile
@@ -4,13 +4,17 @@ RUN apt update
 
 RUN apt upgrade  -y
 
-RUN apt install python3 zsh -y
+RUN apt install python3 python3-venv zsh -y
+
 
 RUN wget https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh -O - | zsh || true
 
 RUN yarn install
 
-RUN pip3 install -r ../docs/requirements.txt
-RUN pip3 install sphinx
+RUN python3 -m venv /opt/venv; mkdir /workspace
 
-CMD ["zsh"]
+COPY docs/requirements.txt /workspace/
+RUN /opt/venv/bin/pip3 install -r /workspace/requirements.txt
+RUN /opt/venv/bin/pip3 install sphinx
+
+CMD . /opt/venv/bin/activate && exec zsh

--- a/.devcontainer/recommended-devcontainer.json
+++ b/.devcontainer/recommended-devcontainer.json
@@ -1,6 +1,13 @@
 {
     "name": "Atomic Calendar Revive",
-    "dockerFile": "Dockerfile",
+    "build": {
+        "context": "..",
+        "dockerfile": "Dockerfile"
+    },
+    "workspaceMount": "",
+    "runArgs": [
+        "--volume=${localWorkspaceFolder}:/workspaces/${localWorkspaceFolderBasename}:Z"
+    ],
     "context": "..",
     "appPorts": [
         5000

--- a/.devcontainer/recommended-devcontainer.json
+++ b/.devcontainer/recommended-devcontainer.json
@@ -6,7 +6,7 @@
     },
     "workspaceMount": "",
     "runArgs": [
-        "--volume=${localWorkspaceFolder}:/workspaces/${localWorkspaceFolderBasename}:Z"
+        "--volume=${localWorkspaceFolder}:/workspaces/${localWorkspaceFolderBasename}"
     ],
     "context": "..",
     "appPorts": [


### PR DESCRIPTION
- Current pip3 refuses to install to system, uses venv instead
- Mounting folder on SELinux systems fails without Z flag.
  This flag is ignored on non-SELinux systems.

fixes: #1063