### PR TITLE
fix: Planner finished-event dimming (#1790) and language config/warning (#1782)

### DIFF
--- a/src/__tests__/localize.test.ts
+++ b/src/__tests__/localize.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { globalData, setHass, setLanguage } from '../helpers/globals';
+import localize from '../localize/localize';
+
+beforeEach(() => {
+	// Reset shared global state between tests.
+	setHass(null as never);
+	setLanguage(null);
+	localStorage.clear();
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe('localize: language resolution', () => {
+	test('falls back to English when nothing is configured', () => {
+		// "common.fullDayEventText" exists in en.json.
+		expect(localize('common.fullDayEventText')).toBe('All Day');
+	});
+
+	test('honours the card-configured language', () => {
+		setLanguage('sk');
+		// Differs from the English string, proving sk.json is used.
+		expect(localize('common.fullDayEventText')).not.toBe('All Day');
+	});
+
+	test('configured language wins over hass locale', () => {
+		setHass({ locale: { language: 'fr' }, language: 'fr' } as never);
+		setLanguage('sk');
+		expect(globalData.language).toBe('sk');
+		const sk = localize('common.fullDayEventText');
+		setLanguage('fr');
+		expect(localize('common.fullDayEventText')).not.toBe(sk);
+	});
+
+	test('does not warn for the literal string "null" in localStorage (#1782)', () => {
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		localStorage.setItem('selectedLanguage', 'null');
+		expect(localize('common.fullDayEventText')).toBe('All Day');
+		expect(warn).not.toHaveBeenCalled();
+	});
+
+	test('does not warn when no language source is set', () => {
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		localize('common.fullDayEventText');
+		expect(warn).not.toHaveBeenCalled();
+	});
+
+	test('warns once for a genuinely unsupported language', () => {
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		setLanguage('xx');
+		expect(localize('common.fullDayEventText')).toBe('All Day');
+		expect(warn).toHaveBeenCalled();
+	});
+});

--- a/src/helpers/globals.ts
+++ b/src/helpers/globals.ts
@@ -4,8 +4,13 @@ import { HomeAssistant } from '../types/homeassistant';
 
 export const globalData = {
 	hass: null as HomeAssistant | null,
+	language: null as string | null,
 };
 
 export function setHass(hass: HomeAssistant) {
 	globalData.hass = hass;
+}
+
+export function setLanguage(language: string | null | undefined) {
+	globalData.language = language ?? null;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ dayjs.extend(advancedFormat);
 import './editor';
 import { CARD_VERSION } from './const';
 import { getDefaultConfig } from './helpers/get-default-config';
-import { setHass } from './helpers/globals';
+import { setHass, setLanguage } from './helpers/globals';
 import { registerCustomCard } from './helpers/register-custom-card';
 import { ICardHost } from './lib/card-host.interface';
 import { getDate } from './lib/common.html';
@@ -96,6 +96,9 @@ export class AtomicCalendarRevive extends LitElement implements ICardHost {
 	public setConfig(config: atomicCardConfig): void {
 		setHass(this.hass);
 		this._config = resolveConfig(config);
+		// Make the card's configured language available to localize() so UI
+		// strings honour the `language` option, not just dayjs date formatting.
+		setLanguage(this._config.language);
 		this.modeToggle = this._config.defaultMode!;
 		this.applyHostCustomProperties();
 	}

--- a/src/lib/views/PlannerView.ts
+++ b/src/lib/views/PlannerView.ts
@@ -120,9 +120,13 @@ export class PlannerView implements ICalendarView {
 			const calendarCells = calendars.map((cal) => {
 				const eventsForCal = dayEvents.filter((e) => e.entity.entity_id === cal.id && !e.isEmpty);
 				return html`<div class="planner-cell">
-					${eventsForCal.map(
-						(event) => html`
-							<div class="planner-event">
+					${eventsForCal.map((event) => {
+						const finishedEventsStyle =
+							event.isFinished && this.config.dimFinishedEvents
+								? `opacity: ` + this.config.finishedEventOpacity + `; filter: ` + this.config.finishedEventFilter + `;`
+								: ``;
+						return html`
+							<div class="planner-event" style="${finishedEventsStyle}">
 								${getTitleHTML(this.config, event, this.hass, 'Planner')}
 								<div class="planner-event-time">
 									${event.isAllDayEvent
@@ -130,8 +134,8 @@ export class PlannerView implements ICalendarView {
 										: `${event.startDateTime.format('LT')}${this.config.showEndTime ? ` - ${event.endDateTime.format('LT')}` : ''}`}
 								</div>
 							</div>
-						`,
-					)}
+						`;
+					})}
 				</div>`;
 			});
 

--- a/src/localize/localize.ts
+++ b/src/localize/localize.ts
@@ -55,9 +55,22 @@ function getTranslatedString(key: string, lang: string): string | undefined {
 
 let languageNotSupportedMessage = false;
 
+// Treat empty strings and the literal string "null"/"undefined" (which can end
+// up persisted in localStorage) as "no language selected" so we fall back to
+// DEFAULT_LANG instead of warning about an unsupported language.
+function normaliseLang(value: string | null | undefined): string | undefined {
+	if (!value) return undefined;
+	const trimmed = value.trim();
+	if (trimmed === '' || trimmed === 'null' || trimmed === 'undefined') return undefined;
+	return trimmed;
+}
+
 export default function localize(key: string) {
 	const lang =
-		(globalData.hass?.locale?.language || globalData.hass?.language || localStorage.getItem('selectedLanguage')) ??
+		normaliseLang(globalData.language) ??
+		normaliseLang(globalData.hass?.locale?.language) ??
+		normaliseLang(globalData.hass?.language) ??
+		normaliseLang(localStorage.getItem('selectedLanguage')) ??
 		DEFAULT_LANG;
 	if (languages[lang]) {
 		// eslint-disable-next-line no-var


### PR DESCRIPTION
Fixes two open bug reports.

## #1790 — Planner View missing `dimFinishedEvents` support
The Planner view never applied the finished-event dimming that the Event and Calendar views already have. It now computes the same `finishedEventsStyle` from `event.isFinished && config.dimFinishedEvents` and applies it to the `.planner-event` div, so finished events dim consistently across all three views.

## #1782 — `Language "null" not supported` warning
Two problems, both fixed:
1. **Config language was ignored.** `localize()` only read `hass.locale` / `localStorage`, never the card's `language` option — that option only affected dayjs date formatting. Added `setLanguage()` to `globals`, wired from `setConfig()`, and made it the highest-priority source in `localize()`. So `language: sk` now translates the UI strings, not just dates.
2. **Spurious warning.** A stale `selectedLanguage="null"` in localStorage (or `localize()` calls from the editor schema before `hass` is set) produced `Language "null" not supported`. Empty / `"null"` / `"undefined"` values are now normalised and fall back to English silently.

## Tests
- New `src/__tests__/localize.test.ts` (6 tests): fallback, config-language precedence, the `"null"` no-warn case, and a genuine unsupported-language warning.
- Full suite passes (124 tests); `tsc`, `eslint`, and `pre-commit run --all-files` all clean.

## Summary by Sourcery

Fix planner view styling to dim finished events consistently and update localization to respect the card’s configured language while avoiding spurious unsupported-language warnings.

Bug Fixes:
- Apply finished-event dimming in Planner view so completed events match Event and Calendar views.
- Ensure the card’s configured language takes precedence in localization instead of being ignored.
- Prevent bogus `Language "null" not supported` warnings by normalising empty or invalid stored language values.

Enhancements:
- Expose a global language setting and wire it through configuration so localization can be driven by card options.

Tests:
- Add unit tests for localization language precedence, fallback behaviour, and handling of invalid language values.