### PR TITLE
fix(inline): make all-day events legible with no per-calendar color

### DIFF
--- a/src/__tests__/inline-event-style.test.ts
+++ b/src/__tests__/inline-event-style.test.ts
@@ -11,12 +11,16 @@ import { resolveInlineEventStyle } from '../lib/views/InlineCalendarView';
 
 describe('resolveInlineEventStyle', () => {
 	test('all-day event with no custom color uses accent fill and contrast text', () => {
-		const event = new EventClass(allDayEvent('2026-04-25', '2026-04-26'), makeConfig());
-		const { background, textColor } = resolveInlineEventStyle(event, makeConfig());
+		const config = makeConfig();
+		const event = new EventClass(allDayEvent('2026-04-25', '2026-04-26'), config);
+		const { background, textColor } = resolveInlineEventStyle(event, config);
 		expect(background).toBe('var(--primary-color)');
 		expect(textColor).toBe('var(--text-primary-color)');
 		// The regression: fill must not equal the text color.
 		expect(background).not.toBe(textColor);
+		// The root cause was both defaulting to defaultCalColor; assert neither does now.
+		expect(background).not.toBe(config.defaultCalColor);
+		expect(textColor).not.toBe(config.defaultCalColor);
 	});
 
 	test('all-day event honours a per-calendar color as the fill', () => {

--- a/src/__tests__/inline-event-style.test.ts
+++ b/src/__tests__/inline-event-style.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from 'vitest';
+
+import { ENTITY, allDayEvent, makeConfig, timedEvent } from './fixtures';
+import EventClass from '../lib/event.class';
+import { resolveInlineEventStyle } from '../lib/views/InlineCalendarView';
+
+// #1794: in Inline mode the all-day bar's background used to default to the same
+// token as its text (both var(--primary-text-color)), making the event invisible
+// whenever no per-calendar color: was configured. The fill must never resolve to
+// the text color.
+
+describe('resolveInlineEventStyle', () => {
+	test('all-day event with no custom color uses accent fill and contrast text', () => {
+		const event = new EventClass(allDayEvent('2026-04-25', '2026-04-26'), makeConfig());
+		const { background, textColor } = resolveInlineEventStyle(event, makeConfig());
+		expect(background).toBe('var(--primary-color)');
+		expect(textColor).toBe('var(--text-primary-color)');
+		// The regression: fill must not equal the text color.
+		expect(background).not.toBe(textColor);
+	});
+
+	test('all-day event honours a per-calendar color as the fill', () => {
+		const coloredEntity = { ...ENTITY, color: '#ff0000' };
+		const event = new EventClass(
+			allDayEvent('2026-04-25', '2026-04-26', 'AllDay', { entity: coloredEntity }),
+			makeConfig(),
+		);
+		const { background, textColor } = resolveInlineEventStyle(event, makeConfig());
+		expect(background).toBe('#ff0000');
+		expect(textColor).toBe('var(--text-primary-color)');
+	});
+
+	test('timed event with no custom color has no fill and defaultCalColor text', () => {
+		const event = new EventClass(timedEvent('2026-04-25T14:00:00', '2026-04-25T15:00:00'), makeConfig());
+		const config = makeConfig();
+		const { background, textColor } = resolveInlineEventStyle(event, config);
+		expect(background).toBe('');
+		expect(textColor).toBe(config.defaultCalColor);
+	});
+
+	test('timed event honours a per-calendar color as the text color', () => {
+		const coloredEntity = { ...ENTITY, color: '#00ff00' };
+		const event = new EventClass(
+			timedEvent('2026-04-25T14:00:00', '2026-04-25T15:00:00', 'Meeting', { entity: coloredEntity }),
+			makeConfig(),
+		);
+		const { background, textColor } = resolveInlineEventStyle(event, makeConfig());
+		expect(background).toBe('');
+		expect(textColor).toBe('#00ff00');
+	});
+});

--- a/src/lib/views/InlineCalendarView.ts
+++ b/src/lib/views/InlineCalendarView.ts
@@ -5,7 +5,34 @@ import { getEntityIcon } from '../../helpers/get-icon';
 import { atomicCardConfig } from '../../types/config';
 import { HomeAssistant } from '../../types/homeassistant';
 import { ICardHost } from '../card-host.interface';
+import EventClass from '../event.class';
 import { ICalendarView } from '../view.interface';
+
+export interface InlineEventStyle {
+	/** CSS `background-color` value, or `''` for no fill (timed events). */
+	background: string;
+	/** CSS `color` value for the bar text and icon. */
+	textColor: string;
+}
+
+// #1794: all-day events render as a filled bar. Both the fill and the text used
+// to default to the same token (`defaultCalColor` and `eventTitleColor` both
+// resolve to `var(--primary-text-color)`), so with no per-calendar `color:` the
+// bar's fill equalled its own text and the event was invisible. Default the fill
+// to the theme accent instead and pair it with `--text-primary-color` (the token
+// intended to contrast solid fills) so the title stays legible; a per-calendar
+// `color:` still overrides the fill. Timed events keep coloured text and no fill.
+export function resolveInlineEventStyle(event: EventClass, config: atomicCardConfig): InlineEventStyle {
+	const customColor = event.entityConfig.color;
+	const hasCustomColor = typeof customColor !== 'undefined';
+	if (event.isAllDayEvent) {
+		return {
+			background: hasCustomColor ? customColor : 'var(--primary-color)',
+			textColor: 'var(--text-primary-color)',
+		};
+	}
+	return { background: '', textColor: hasCustomColor ? customColor : config.defaultCalColor };
+}
 
 export class InlineCalendarView implements ICalendarView {
 	private grid: MonthGrid;
@@ -37,11 +64,9 @@ export class InlineCalendarView implements ICalendarView {
 
 	private renderEvents(day: CalendarDay): TemplateResult[] {
 		return day.allEvents.map((event) => {
-			const eventColor =
-				typeof event.entityConfig.color !== 'undefined' ? event.entityConfig.color : this.config.defaultCalColor;
 			const isAllDay = event.isAllDayEvent;
-			const titleColor = isAllDay ? this.config.eventTitleColor : eventColor;
-			const backgroundStyle = isAllDay ? `background-color: ${eventColor};` : '';
+			const { background, textColor: titleColor } = resolveInlineEventStyle(event, this.config);
+			const backgroundStyle = background ? `background-color: ${background};` : '';
 			const time = !isAllDay
 				? `${event.startDateTime.format('LT')}${this.config.showEndTime ? ` - ${event.endDateTime.format('LT')}` : ''}`
 				: '';


### PR DESCRIPTION
## Summary

Fixes #1794. In Inline mode, all-day events with no per-calendar `color:` set were invisible.

**Root cause:** the all-day bar derived its background fill and its text from tokens that both default to `var(--primary-text-color)` - `defaultCalColor` (fill) and `eventTitleColor` (text). With no per-calendar color, the box's fill equalled its own text, so the event rendered blank. Both were inline `style=` attributes, so theme/card_mod overrides could not correct it without `!important`.

## Change

- Default the all-day fill to `var(--primary-color)` (still overridable by a per-calendar `color:`).
- Pair it with `var(--text-primary-color)`, the token intended to contrast solid fills, so the title stays legible out of the box.
- Timed events are unchanged.
- Colour logic extracted into a pure, unit-tested `resolveInlineEventStyle` helper.

This matches the accent-bar-with-contrasting-text convention used by Google/Apple/Outlook for all-day events (and the reporter's own card_mod workaround).

## Verification

- New `src/__tests__/inline-event-style.test.ts` (4 cases) asserts the fill never equals the text colour, per-calendar colour overrides the fill, and timed events are untouched.
- Full suite: 128/128 pass. Lint clean, production build clean.
- **Verified end-to-end in a live HA instance** (Inline mode, `calendar.family`, no `color:`): the all-day event now renders as a filled accent bar with white text (`background: rgb(0,154,199)` / `color: rgb(255,255,255)`), confirmed via computed styles in the shadow DOM.

## Summary by Sourcery

Ensure inline all-day calendar events remain visible and legible when no per-calendar color is configured.

New Features:
- Introduce a reusable resolveInlineEventStyle helper to centralize inline event color selection for inline calendar view.

Bug Fixes:
- Fix invisible all-day events in inline view when no per-calendar color is set by using contrasting theme tokens for fill and text.

Enhancements:
- Align all-day event styling with theme accent and contrasting text while preserving existing behavior for timed events.

Tests:
- Add unit tests for resolveInlineEventStyle covering all-day and timed events with and without custom colors.