### PR TITLE
fix: complete Spanish (es) localization

### DIFF
--- a/src/localize/languages/es.json
+++ b/src/localize/languages/es.json
@@ -57,7 +57,7 @@
 			"showAllDayEvents": "Mostrar eventos de todo el día",
 			"offsetHeaderDate": "Fecha de encabezado de compensación",
 			"startDaysAhead": "Eventos que comienzan `x` días desde hoy",
-			"showPastDaysOfWeek": "Anchor window to start of current week"
+			"showPastDaysOfWeek": "Anclar ventana al inicio de la semana actual"
 		}
 	},
 	"event": {
@@ -98,6 +98,14 @@
 			"disableCalLocationLink": "¿Desactivar enlace de ubicación del calendario?",
 			"calShowDescription": "¿Mostrar descripción del calendario?",
 			"disableCalLink": "¿Desactivar enlace del calendario?"
+		}
+	},
+	"planner": {
+		"name": "Modo Planificador",
+		"secondary": "Opciones específicas del Modo Planificador",
+		"fields": {
+			"plannerDaysToShow": "Días a mostrar",
+			"plannerRollingWeek": "Semana móvil (comenzar hoy)"
 		}
 	},
 	"appearance": {


### PR DESCRIPTION
## Proposed Change

Completes the existing `es.json` (Spanish) locale file, which was missing the entire `planner` section and had one untranslated field (`showPastDaysOfWeek`). All keys now match `en.json` exactly.

## Related issues

N/A - translation completeness fix, no existing issue found for this specific gap.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Summary by Sourcery

Bug Fixes:
- Add the missing Spanish translations for the planner section and ensure all locale keys exist in es.json, including previously untranslated fields.