### PR TITLE
feat(event): add showTodayTomorrow option for relative day labels

### DIFF
--- a/docs/configuration/event.rst
+++ b/docs/configuration/event.rst
@@ -21,5 +21,6 @@ Event Mode Options
  hoursOnSameLine         boolean    ``false`` if set true will move hours to show on the same line as the summary.
  showAllDayHours         boolean    ``true`` Show "All Day" text under full day events
  eventDateFormat         string     ``ddd D MMM`` Set the date format for events (`Reference <https://day.js.org/docs/en/display/format>`_)
+ showTodayTomorrow       boolean    ``false`` Show a localized "Today"/"Tomorrow" label instead of the date for those two days (other days keep ``eventDateFormat``)
  hideCardIfNoEvents      boolean    ``false`` Hides the entire card if there are no events to display
 ======================= ========== ===========================================================================================================

--- a/src/__tests__/event-date-text.test.ts
+++ b/src/__tests__/event-date-text.test.ts
@@ -1,0 +1,57 @@
+import dayjs from 'dayjs';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+
+import { makeConfig } from './fixtures';
+import { setLanguage } from '../helpers/globals';
+import { getEventDateText } from '../lib/common.html';
+
+// Discussion #1815: an opt-in `showTodayTomorrow` option substitutes a localized
+// "Today"/"Tomorrow" label for events falling on those two days, while every other
+// day keeps the configured `eventDateFormat`.
+
+beforeEach(() => {
+	setLanguage(null);
+	localStorage.clear();
+});
+
+afterEach(() => {
+	setLanguage(null);
+	localStorage.clear();
+});
+
+describe('getEventDateText', () => {
+	test('uses the localized "Today" label for today when enabled', () => {
+		const config = makeConfig({ showTodayTomorrow: true });
+		expect(getEventDateText(config, dayjs().startOf('day'))).toBe('Today');
+	});
+
+	test('uses the localized "Tomorrow" label for tomorrow when enabled', () => {
+		const config = makeConfig({ showTodayTomorrow: true });
+		expect(getEventDateText(config, dayjs().add(1, 'day').startOf('day'))).toBe('Tomorrow');
+	});
+
+	test('falls back to eventDateFormat for days beyond tomorrow', () => {
+		const config = makeConfig({ showTodayTomorrow: true, eventDateFormat: 'ddd D MMM' });
+		const inThreeDays = dayjs().add(3, 'day').startOf('day');
+		expect(getEventDateText(config, inThreeDays)).toBe(inThreeDays.format('ddd D MMM'));
+	});
+
+	test('always uses eventDateFormat when the option is disabled', () => {
+		const config = makeConfig({ showTodayTomorrow: false, eventDateFormat: 'ddd D MMM' });
+		const today = dayjs().startOf('day');
+		expect(getEventDateText(config, today)).toBe(today.format('ddd D MMM'));
+	});
+
+	test('honours the configured language for the relative labels', () => {
+		setLanguage('de');
+		const config = makeConfig({ showTodayTomorrow: true });
+		expect(getEventDateText(config, dayjs().startOf('day'))).toBe('Heute');
+		expect(getEventDateText(config, dayjs().add(1, 'day').startOf('day'))).toBe('Morgen');
+	});
+
+	test('matches today regardless of the time of day', () => {
+		const config = makeConfig({ showTodayTomorrow: true });
+		// Late-in-the-day timestamp must still be recognised as "today".
+		expect(getEventDateText(config, dayjs().endOf('day'))).toBe('Today');
+	});
+});

--- a/src/__tests__/event-date-text.test.ts
+++ b/src/__tests__/event-date-text.test.ts
@@ -54,4 +54,10 @@ describe('getEventDateText', () => {
 		// Late-in-the-day timestamp must still be recognised as "today".
 		expect(getEventDateText(config, dayjs().endOf('day'))).toBe('Today');
 	});
+
+	test('matches tomorrow regardless of the time of day', () => {
+		const config = makeConfig({ showTodayTomorrow: true });
+		// Late-in-the-day timestamp must still be recognised as "tomorrow".
+		expect(getEventDateText(config, dayjs().add(1, 'day').endOf('day'))).toBe('Tomorrow');
+	});
 });

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -89,6 +89,7 @@ export default {
 
 	showEventIcon: false,
 	eventDateFormat: 'ddd D MMM',
+	showTodayTomorrow: false,
 	hideDuplicates: false,
 
 	showMultiDay: false,

--- a/src/editor-schema.ts
+++ b/src/editor-schema.ts
@@ -74,6 +74,7 @@ export const eventSchema = [
 	{ name: 'noEventText', label: localize('event.fields.noEventText'), selector: { text: {} } },
 	{ name: 'hiddenEventText', label: localize('event.fields.hiddenEventText'), selector: { text: {} } },
 	{ name: 'eventDateFormat', label: localize('event.fields.eventDateFormat'), selector: { text: {} } },
+	{ name: 'showTodayTomorrow', label: localize('event.fields.showTodayTomorrow'), selector: { boolean: {} } },
 	{ name: 'disableEventLink', label: localize('event.fields.disableEventLink'), selector: { boolean: {} } },
 	{ name: 'disableLocationLink', label: localize('event.fields.disableLocationLink'), selector: { boolean: {} } },
 	{ name: 'showNoEventsForToday', label: localize('event.fields.showNoEventsForToday'), selector: { boolean: {} } },

--- a/src/lib/common.html.ts
+++ b/src/lib/common.html.ts
@@ -5,6 +5,7 @@ import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 
 import EventClass from './event.class';
 import { getEventIcon } from '../helpers/get-icon';
+import localize from '../localize/localize';
 import { atomicCardConfig } from '../types/config';
 import { HomeAssistant } from '../types/homeassistant';
 
@@ -76,6 +77,27 @@ export function getDate(config: atomicCardConfig) {
 		date = dayjs().add(config.startDaysAhead, 'day').format(config.dateFormat);
 	}
 	return html`${date}`;
+}
+
+/**
+ * Returns the date label shown in an event's day header. When `showTodayTomorrow`
+ * is enabled, events falling on today or tomorrow display a localized "Today" or
+ * "Tomorrow" label; every other day falls back to the configured `eventDateFormat`.
+ * @param config card configuration
+ * @param eventDate the (clamped) start time used for the event's date header
+ * @returns the label string to render
+ */
+export function getEventDateText(config: atomicCardConfig, eventDate: dayjs.Dayjs): string {
+	if (config.showTodayTomorrow) {
+		const today = dayjs().startOf('day');
+		if (eventDate.isSame(today, 'day')) {
+			return localize('common.today');
+		}
+		if (eventDate.isSame(today.add(1, 'day'), 'day')) {
+			return localize('common.tomorrow');
+		}
+	}
+	return eventDate.format(config.eventDateFormat);
 }
 
 /**

--- a/src/lib/views/EventView.ts
+++ b/src/lib/views/EventView.ts
@@ -6,7 +6,14 @@ import localize from '../../localize/localize';
 import { atomicCardConfig } from '../../types/config';
 import { HomeAssistant } from '../../types/homeassistant';
 import { ICardHost } from '../card-host.interface';
-import { getCurrDayAndMonth, getDescription, getLocationHTML, getTitleHTML, setNoEventDays } from '../common.html';
+import {
+	getCurrDayAndMonth,
+	getDescription,
+	getEventDateText,
+	getLocationHTML,
+	getTitleHTML,
+	setNoEventDays,
+} from '../common.html';
 import EventClass from '../event.class';
 import { fetchEventModeEvents, groupEventsByDay } from '../pipeline';
 import { ICalendarView } from '../view.interface';
@@ -200,7 +207,7 @@ export class EventView implements ICalendarView {
 
 				// check and set the date format
 				const eventDate = showDatePerEvent
-					? html`<div class="event-date-day">${event.startTimeToShow.format(this.config.eventDateFormat)}</div>`
+					? html`<div class="event-date-day">${getEventDateText(this.config, event.startTimeToShow)}</div>`
 					: html``;
 
 				const dayClassTodayEvent = event.startTimeToShow.isSame(dayjs(), 'day') ? `current-day` : ``;

--- a/src/localize/languages/ca.json
+++ b/src/localize/languages/ca.json
@@ -8,7 +8,9 @@
 		"untilText": "Fins",
 		"noEventText": "Sense esdeveniments",
 		"noEventsForNextDaysText": "Sense esdeveniments en els propers dies",
-		"hiddenEventText": "esdeveniments ocults"
+		"hiddenEventText": "esdeveniments ocults",
+		"today": "Avui",
+		"tomorrow": "Demà"
 	},
 	"ui": {
 		"common": {
@@ -86,7 +88,8 @@
 			"showTimeRemaining": "Mostrar temps restant",
 			"showAllDayHours": "Mostrar text d'esdeveniment de tot el dia",
 			"hoursOnSameLine": "Mostrar hores a la línia de l'esdeveniment",
-			"eventDateFormat": "Format de data de l'esdeveniment"
+			"eventDateFormat": "Format de data de l'esdeveniment",
+			"showTodayTomorrow": "Mostrar etiquetes Avui/Demà?"
 		}
 	},
 	"calendar": {

--- a/src/localize/languages/cs.json
+++ b/src/localize/languages/cs.json
@@ -8,7 +8,9 @@
 		"untilText": "Do",
 		"noEventText": "Žádné události",
 		"noEventsForNextDaysText": "Žádné události v následujících dnech",
-		"hiddenEventText": "události jsou skyty"
+		"hiddenEventText": "události jsou skyty",
+		"today": "Dnes",
+		"tomorrow": "Zítra"
 	},
 	"ui": {
 		"common": {
@@ -75,7 +77,8 @@
 			"showWeekNumber": "Zobrazit číslo týdne",
 			"showEventDate": "Zobrazit datum události",
 			"showDatePerEvent": "Zobrazit datum u každé události",
-			"eventDateFormat": "Formát data události"
+			"eventDateFormat": "Formát data události",
+			"showTodayTomorrow": "Zobrazit popisky Dnes/Zítra?"
 		}
 	},
 	"calendar": {

--- a/src/localize/languages/da.json
+++ b/src/localize/languages/da.json
@@ -8,7 +8,9 @@
 		"untilText": "Indtil",
 		"noEventText": "Ingen aftaler",
 		"noEventsForNextDaysText": "Ingen aftaler de næste få dage",
-		"hiddenEventText": "Aftaler er skjulte"
+		"hiddenEventText": "Aftaler er skjulte",
+		"today": "I dag",
+		"tomorrow": "I morgen"
 	},
 	"ui": {
 		"common": {
@@ -86,7 +88,8 @@
 			"showTimeRemaining": "Vis resterende tid",
 			"showAllDayHours": "Vis Heldagsbegivenhedstekst",
 			"hoursOnSameLine": "Vis timer på begivenhedslinjen",
-			"eventDateFormat": "Begivenhedsdatoformat"
+			"eventDateFormat": "Begivenhedsdatoformat",
+			"showTodayTomorrow": "Vis I dag/I morgen-etiketter?"
 		}
 	},
 	"calendar": {

--- a/src/localize/languages/de.json
+++ b/src/localize/languages/de.json
@@ -8,7 +8,9 @@
 		"untilText": "Bis",
 		"noEventText": "Keine Einträge",
 		"noEventsForNextDaysText": "Keine Einträge in den nächsten Tagen",
-		"hiddenEventText": "Einträge sind ausgeblendet."
+		"hiddenEventText": "Einträge sind ausgeblendet.",
+		"today": "Heute",
+		"tomorrow": "Morgen"
 	},
 	"ui": {
 		"common": {
@@ -86,7 +88,8 @@
 			"showTimeRemaining": "Verbleibende Zeit anzeigen?",
 			"showAllDayHours": "Ganztägigen Ereignistext anzeigen?",
 			"hoursOnSameLine": "Stunden auf der Ereigniszeile anzeigen?",
-			"eventDateFormat": "Ereignisdatumsformat"
+			"eventDateFormat": "Ereignisdatumsformat",
+			"showTodayTomorrow": "Labels Heute/Morgen anzeigen?"
 		}
 	},
 	"calendar": {

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -8,7 +8,9 @@
 		"untilText": "Until",
 		"noEventText": "No events",
 		"noEventsForNextDaysText": "No events in the next few days",
-		"hiddenEventText": "events are hidden"
+		"hiddenEventText": "events are hidden",
+		"today": "Today",
+		"tomorrow": "Tomorrow"
 	},
 	"ui": {
 		"common": {
@@ -86,7 +88,8 @@
 			"showTimeRemaining": "Show time remaining",
 			"showAllDayHours": "Show All Day event text",
 			"hoursOnSameLine": "Show hours on the event line",
-			"eventDateFormat": "Event date format"
+			"eventDateFormat": "Event date format",
+			"showTodayTomorrow": "Show Today/Tomorrow labels?"
 		}
 	},
 	"calendar": {

--- a/src/localize/languages/es.json
+++ b/src/localize/languages/es.json
@@ -8,7 +8,9 @@
 		"untilText": "Hasta",
 		"noEventText": "Sin eventos",
 		"noEventsForNextDaysText": "Sin eventos en los próximos días",
-		"hiddenEventText": "eventos están ocultos"
+		"hiddenEventText": "eventos están ocultos",
+		"today": "Hoy",
+		"tomorrow": "Mañana"
 	},
 	"ui": {
 		"common": {
@@ -86,7 +88,8 @@
 			"showTimeRemaining": "¿Mostrar tiempo restante?",
 			"showAllDayHours": "¿Mostrar texto de evento de todo el día?",
 			"hoursOnSameLine": "¿Mostrar horas en la línea de evento?",
-			"eventDateFormat": "Formato de fecha del evento"
+			"eventDateFormat": "Formato de fecha del evento",
+			"showTodayTomorrow": "¿Mostrar etiquetas Hoy/Mañana?"
 		}
 	},
 	"calendar": {

--- a/src/localize/languages/et.json
+++ b/src/localize/languages/et.json
@@ -8,7 +8,9 @@
 		"untilText": "Kuni",
 		"noEventText": "üritusi pole",
 		"noEventsForNextDaysText": "Paari järgmise päeva sündmusi pole",
-		"hiddenEventText": "Sündmused on varjatud"
+		"hiddenEventText": "Sündmused on varjatud",
+		"today": "Täna",
+		"tomorrow": "Homme"
 	},
 	"ui": {
 		"common": {
@@ -84,7 +86,8 @@
 			"showTimeRemaining": "Näita järelejäänud aega",
 			"showAllDayHours": "Näita kogu päeva sündmuse teksti",
 			"hoursOnSameLine": "Näidake sündmuse reale tundi",
-			"eventDateFormat": "Sündmuse kuupäeva vorming"
+			"eventDateFormat": "Sündmuse kuupäeva vorming",
+			"showTodayTomorrow": "Kuva sildid Täna/Homme?"
 		}
 	},
 	"calendar": {

--- a/src/localize/languages/fi.json
+++ b/src/localize/languages/fi.json
@@ -8,7 +8,9 @@
 		"untilText": "Asti",
 		"noEventText": "Ei tapahtumia",
 		"noEventsForNextDaysText": "Ei tapahtumia lähipäivinä",
-		"hiddenEventText": "tapahtumaa on piilotettu"
+		"hiddenEventText": "tapahtumaa on piilotettu",
+		"today": "Tänään",
+		"tomorrow": "Huomenna"
 	},
 	"ui": {
 		"common": {
@@ -86,7 +88,8 @@
 			"showTimeRemaining": "Näytä jäljellä oleva aika",
 			"showAllDayHours": "Näytä koko päivän tapahtuman teksti",
 			"hoursOnSameLine": "Näytä tunnit tapahtumarivillä",
-			"eventDateFormat": "Tapahtuman päivämäärän muoto"
+			"eventDateFormat": "Tapahtuman päivämäärän muoto",
+			"showTodayTomorrow": "Näytä Tänään/Huomenna-tunnisteet?"
 		}
 	},
 	"calendar": {

--- a/src/localize/languages/fr.json
+++ b/src/localize/languages/fr.json
@@ -8,7 +8,9 @@
 		"untilText": "Jusqu'au",
 		"noEventText": "pas d'événements",
 		"noEventsForNextDaysText": "Aucun événement dans les prochains jours",
-		"hiddenEventText": "les événements sont masqués"
+		"hiddenEventText": "les événements sont masqués",
+		"today": "Aujourd'hui",
+		"tomorrow": "Demain"
 	},
 	"ui": {
 		"common": {
@@ -86,7 +88,8 @@
 			"showTimeRemaining": "Afficher le temps restant",
 			"showAllDayHours": "Afficher le texte de l'événement toute la journée",
 			"hoursOnSameLine": "Afficher les heures sur la ligne de l'événement",
-			"eventDateFormat": "Format de la date de l'événement"
+			"eventDateFormat": "Format de la date de l'événement",
+			"showTodayTomorrow": "Afficher les libellés Aujourd'hui/Demain"
 		}
 	},
 	"calendar": {

--- a/src/localize/languages/hu.json
+++ b/src/localize/languages/hu.json
@@ -8,7 +8,9 @@
 		"untilText": "Amíg",
 		"noEventText": "Nincs esemény",
 		"noEventsForNextDaysText": "Nincsenek események a következő napokra",
-		"hiddenEventText": "az események elrejtve"
+		"hiddenEventText": "az események elrejtve",
+		"today": "Ma",
+		"tomorrow": "Holnap"
 	},
 	"ui": {
 		"common": {
@@ -86,7 +88,8 @@
 			"showTimeRemaining": "Hátralévő idő megjelenítése",
 			"showAllDayHours": "Egész napos esemény szöveg megjelenítése",
 			"hoursOnSameLine": "Az idő megjelenítése az esemény sorában",
-			"eventDateFormat": "Esemény dátumának formátuma"
+			"eventDateFormat": "Esemény dátumának formátuma",
+			"showTodayTomorrow": "Ma/Holnap címkék megjelenítése?"
 		}
 	},
 	"calendar": {

--- a/src/localize/languages/nb.json
+++ b/src/localize/languages/nb.json
@@ -8,7 +8,9 @@
 		"untilText": "Inntil",
 		"noEventText": "Ingen hendelser",
 		"noEventsForNextDaysText": "Ingen hendelser de nærmeste dager",
-		"hiddenEventText": "hendelser er skjulte"
+		"hiddenEventText": "hendelser er skjulte",
+		"today": "I dag",
+		"tomorrow": "I morgen"
 	},
 	"ui": {
 		"common": {
@@ -86,7 +88,8 @@
 			"showTimeRemaining": "Vis gjenværende tid",
 			"showAllDayHours": "Vis tekst for hele dagen",
 			"hoursOnSameLine": "Vis timer på arrangementslinjen",
-			"eventDateFormat": "Datoformat for hendelsen"
+			"eventDateFormat": "Datoformat for hendelsen",
+			"showTodayTomorrow": "Vis I dag/I morgen-etiketter?"
 		}
 	},
 	"calendar": {

--- a/src/localize/languages/nl.json
+++ b/src/localize/languages/nl.json
@@ -8,7 +8,9 @@
 		"untilText": "Tot",
 		"noEventText": "Geen gebeurtenissen",
 		"noEventsForNextDaysText": "Geen gebeurtenissen in de komende dagen",
-		"hiddenEventText": "gebeurtenissen zijn verborgen"
+		"hiddenEventText": "gebeurtenissen zijn verborgen",
+		"today": "Vandaag",
+		"tomorrow": "Morgen"
 	},
 	"ui": {
 		"common": {
@@ -87,7 +89,8 @@
 			"showTimeRemaining": "Toon resterende tijd",
 			"showAllDayHours": "Toon uren voor hele dag gebeurtenissen",
 			"hoursOnSameLine": "Toon uren op de gebeurtenislijn",
-			"eventDateFormat": "Datumformaat gebeurtenis"
+			"eventDateFormat": "Datumformaat gebeurtenis",
+			"showTodayTomorrow": "Labels Vandaag/Morgen tonen?"
 		}
 	},
 	"calendar": {

--- a/src/localize/languages/pt.json
+++ b/src/localize/languages/pt.json
@@ -8,7 +8,9 @@
 		"untilText": "Até",
 		"noEventText": "Sem eventos",
 		"noEventsForNextDaysText": "Sem eventos nos próximos dias",
-		"hiddenEventText": "eventos escondidos"
+		"hiddenEventText": "eventos escondidos",
+		"today": "Hoje",
+		"tomorrow": "Amanhã"
 	},
 	"ui": {
 		"common": {
@@ -86,7 +88,8 @@
 			"showTimeRemaining": "Mostrar tempo restante",
 			"showAllDayHours": "Mostrar texto evento dia completo",
 			"hoursOnSameLine": "Mostrar horas na linha do evento",
-			"eventDateFormat": "Formato de data do evento"
+			"eventDateFormat": "Formato de data do evento",
+			"showTodayTomorrow": "Mostrar etiquetas Hoje/Amanhã?"
 		}
 	},
 	"calendar": {

--- a/src/localize/languages/ru.json
+++ b/src/localize/languages/ru.json
@@ -8,7 +8,9 @@
 		"untilText": "До",
 		"noEventText": "Нет событий",
 		"noEventsForNextDaysText": "Нет событий в ближайшие дни",
-		"hiddenEventText": "события скрыты"
+		"hiddenEventText": "события скрыты",
+		"today": "Сегодня",
+		"tomorrow": "Завтра"
 	},
 	"ui": {
 		"common": {
@@ -86,7 +88,8 @@
 			"showTimeRemaining": "Показать оставшееся время",
 			"showAllDayHours": "Показать текст события на весь день",
 			"hoursOnSameLine": "Показать часы на строке события",
-			"eventDateFormat": "Формат даты события"
+			"eventDateFormat": "Формат даты события",
+			"showTodayTomorrow": "Показывать метки Сегодня/Завтра"
 		}
 	},
 	"calendar": {

--- a/src/localize/languages/sk.json
+++ b/src/localize/languages/sk.json
@@ -8,7 +8,9 @@
 		"untilText": "do",
 		"noEventText": "Žiadne udalosti",
 		"noEventsForNextDaysText": "Žiadne udalosti v najbližších dňoch",
-		"hiddenEventText": "udalosti sú skryté"
+		"hiddenEventText": "udalosti sú skryté",
+		"today": "Dnes",
+		"tomorrow": "Zajtra"
 	},
 	"ui": {
 		"common": {
@@ -86,7 +88,8 @@
 			"showTimeRemaining": "Zobraziť zostávajúci čas",
 			"showAllDayHours": "Zobraziť text celodennej udalosti",
 			"hoursOnSameLine": "Zobraziť hodiny na riadku udalosti",
-			"eventDateFormat": "Formát dátumu udalosti"
+			"eventDateFormat": "Formát dátumu udalosti",
+			"showTodayTomorrow": "Zobraziť štítky Dnes/Zajtra?"
 		}
 	},
 	"calendar": {

--- a/src/localize/languages/sl.json
+++ b/src/localize/languages/sl.json
@@ -8,7 +8,9 @@
 		"untilText": "Do",
 		"noEventText": "Ni dogodkov",
 		"noEventsForNextDaysText": "Ni dogodkov v naslednjih nekaj dneh",
-		"hiddenEventText": "dogodki so skriti"
+		"hiddenEventText": "dogodki so skriti",
+		"today": "Danes",
+		"tomorrow": "Jutri"
 	},
 	"ui": {
 		"common": {
@@ -86,7 +88,8 @@
 			"showTimeRemaining": "Pokaži preostali čas",
 			"showAllDayHours": "Prikaži besedilo celodnevnega dogodka",
 			"hoursOnSameLine": "Prikaži ure na vrstici dogodkov",
-			"eventDateFormat": "Oblika datuma dogodka"
+			"eventDateFormat": "Oblika datuma dogodka",
+			"showTodayTomorrow": "Prikaži oznake Danes/Jutri?"
 		}
 	},
 	"calendar": {

--- a/src/localize/languages/sv.json
+++ b/src/localize/languages/sv.json
@@ -8,7 +8,9 @@
 		"untilText": "Tills",
 		"noEventText": "Inga händelser",
 		"noEventsForNextDaysText": "Inga händelser de närmaste dagarna",
-		"hiddenEventText": "händelser är dolda"
+		"hiddenEventText": "händelser är dolda",
+		"today": "Idag",
+		"tomorrow": "Imorgon"
 	},
 	"ui": {
 		"common": {
@@ -85,7 +87,8 @@
 			"showTimeRemaining": "Visa återstående tid",
 			"showAllDayHours": "Visa heldagshändelsetext",
 			"hoursOnSameLine": "Visa öppettider på evenemangsraden",
-			"eventDateFormat": "Händelsedatumformat"
+			"eventDateFormat": "Händelsedatumformat",
+			"showTodayTomorrow": "Visa etiketter Idag/Imorgon?"
 		}
 	},
 	"calendar": {

--- a/src/localize/languages/uk.json
+++ b/src/localize/languages/uk.json
@@ -8,7 +8,9 @@
 		"untilText": "До",
 		"noEventText": "Немає подій",
 		"noEventsForNextDaysText": "Немає подій на найближчі дні",
-		"hiddenEventText": "події приховані"
+		"hiddenEventText": "події приховані",
+		"today": "Сьогодні",
+		"tomorrow": "Завтра"
 	},
 	"ui": {
 		"common": {
@@ -86,7 +88,8 @@
 			"showTimeRemaining": "Показувати залишок часу",
 			"showAllDayHours": "Показувати текст цілоденних подій",
 			"hoursOnSameLine": "Показувати години на лінії події",
-			"eventDateFormat": "Формат дати події"
+			"eventDateFormat": "Формат дати події",
+			"showTodayTomorrow": "Показувати мітки Сьогодні/Завтра"
 		}
 	},
 	"calendar": {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -46,6 +46,7 @@ export interface atomicCardConfig {
 	showEventDate: boolean;
 	showDatePerEvent: boolean;
 	showRelativeTime?: boolean;
+	showTodayTomorrow?: boolean;
 	eventDateFormat: string;
 	showWeekNumber?: boolean;
 	showAllDayEvents: boolean;


### PR DESCRIPTION
## Summary

Implements the request from discussion #1815: an opt-in Event Mode option that shows a **"Today"/"Tomorrow"** label instead of the date for those two days, falling back to `eventDateFormat` for every other day.

The name is `showTodayTomorrow` rather than "relative date" because only today and tomorrow are relabelled - everything else keeps the configured format, so calling it "relative" would overstate the scope.

## Behaviour

| Event day | Displayed |
|-----------|-----------|
| Today | `Today` (localized) |
| Tomorrow | `Tomorrow` (localized) |
| Anything else | `eventDateFormat` (default `ddd D MMM`) |

Off by default, so existing cards are unchanged.

## Changes

- **`getEventDateText()`** helper in `common.html.ts` (pure + unit-tested), consumed by the Event Mode day-header render in `EventView.ts`.
- New `showTodayTomorrow` config option: type, default (`false`), and a boolean toggle in the visual editor.
- Localization: added `common.today`, `common.tomorrow`, and the editor label `event.fields.showTodayTomorrow` to **all 18 language files** with per-language translations. This was required rather than optional - the localize fallback only covers an unsupported *language*, not a missing *key*, so a missing key would render the raw string.
- Documented in `docs/configuration/event.rst`.

Uses the card's own i18n system rather than dayjs's `calendar` plugin, to avoid maintaining a second parallel set of locale strings.

## Testing

- 6 new unit tests (`event-date-text.test.ts`): today, tomorrow, day-after fallback, disabled, localized labels (de → Heute/Morgen), time-of-day independence.
- Full suite: 134 passing. ESLint clean. `pre-commit run --all-files` passes. `pnpm run build` succeeds.

## Note for reviewers

The 18 translations were authored by me. "Today"/"Tomorrow" are high-confidence common vocabulary; the editor-label phrasings are reasonable but a native-speaker sanity check on tone before release would be welcome.

Closes #1815

cc discussion #1815

## Summary by Sourcery

Add an optional configuration to show localized "Today"/"Tomorrow" labels in event day headers instead of dates for those two days.

New Features:
- Introduce a showTodayTomorrow option that replaces the event header date with localized "Today"/"Tomorrow" labels for events occurring on those days.

Enhancements:
- Centralize event day header label generation in a reusable getEventDateText helper that respects the new option and existing date format configuration.

Documentation:
- Document the showTodayTomorrow option and its behavior in the event configuration documentation.

Tests:
- Add unit tests covering getEventDateText behavior for today, tomorrow, other days, disabled configuration, localization, and time-of-day handling.

Chores:
- Add today/tomorrow and editor label localization keys for all supported languages to support the new relative labels.